### PR TITLE
studentListing bug (student not found)  resolved

### DIFF
--- a/src/Pages/Admin/Pages/StudentListing.jsx
+++ b/src/Pages/Admin/Pages/StudentListing.jsx
@@ -15,8 +15,8 @@ const StudentListingpage = () => {
 
       const res = await axios.get("http://localhost:3000/getstudents");
 
-      console.log(res.data.students);
-      setStudents(res.data.students);
+      console.log(res.data.allUser);
+      setStudents(res.data.allUser);
       setLoading(false);
     }
     fetchStudents();


### PR DESCRIPTION
the student Listing page showed "Student not found" this was because of res.data.students was falsely passed to the useEffect hook, the res to send was res.data.allUser